### PR TITLE
Location aware balancer based on linked list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ ydb.WithQueryTimeout(5*time.Minute),
 // Session pool size, default is 10.
 ydb.WithSessionPoolSize(50),
 
-// Session pool ready Low and High thresholds.
-// If amount of ready sessions hit High threshold,
+// Session pool ready Low and High thresholds (in percents).
+// If sum of idle and inuse sessions hits High threshold,
 // then client.Ready() returns true.
-// If amount of ready sessions hit Low threshold,
-// then client.Ready() returns false.
+// If this sum hits Low threshold, then client.Ready() is false.
+// This suites for readiness probes, but should not
+// be used to handle pool congestion.
 // Possible values are 0<=low<high<=100.
 // Default is low=0, high=50
 ydb.WithSessionPoolReadyThresholds(10, 80)
@@ -108,10 +109,10 @@ ydb.WithConnectionsPerEndpoint(4)
 // When making balancing decision, client's balancer will look
 // for connections from locations in order specified by this param.
 // If all connections in first location are not alive, it will move to next.
-// If there's no alive connections in ether of these locations,
+// If there's no alive connections in either of these locations,
 // alive connections from other discovered locations (if any) will be used.
 // If this param is not specified or empty, balancer will treat all
-// connections as if they are from the same location.
+// connections as if they are from same location.
 // Within location balancer selects connection using round-robin approach.
 ydb.WithLocationPreference([]string{"ru-central1-b", "ru-central1-a"})
 

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/adwski/ydb-go-query/internal/logger"
 	"github.com/adwski/ydb-go-query/internal/query"
 	"github.com/adwski/ydb-go-query/internal/transport"
-	balancer "github.com/adwski/ydb-go-query/internal/transport/balancing/v3"
+	balancing "github.com/adwski/ydb-go-query/internal/transport/balancing/v4"
 	"github.com/adwski/ydb-go-query/internal/transport/dispatcher"
 	qq "github.com/adwski/ydb-go-query/query"
 )
@@ -122,7 +122,7 @@ func newClient(ctx context.Context, cfg *Config, opts ...Option) (*Client, error
 		Logger:    cfg.logger,
 		InitNodes: cfg.InitialNodes,
 		DB:        cfg.DB,
-		Balancer: balancer.Config{
+		Balancing: balancing.Config{
 			LocationPreference: cfg.locationPreference,
 			ConnsPerEndpoint:   cfg.connectionsPerEndpoint,
 			IgnoreLocations:    false,

--- a/internal/transport/balancing/v4/grid.go
+++ b/internal/transport/balancing/v4/grid.go
@@ -1,0 +1,291 @@
+package v3
+
+import (
+	"errors"
+	"sync"
+)
+
+const (
+	defaultLocation = "&&def"
+
+	minConnectionsPerEndpoint = 1
+)
+
+var (
+	ErrConnCreate = errors.New("connection create failed")
+
+	ErrUnknownLocation = errors.New("unknown location")
+	ErrNoSuchID        = errors.New("no such id")
+	ErrEmptyLocation   = errors.New("empty location")
+)
+
+type (
+	connection[T any] interface {
+		*T
+
+		Alive() bool
+		Close() error
+		ID() uint64
+	}
+
+	node[PT connection[T], T any] struct {
+		next *node[PT, T]
+		conn PT
+	}
+
+	locationData[PT connection[T], T any] struct {
+		lookupPtr *node[PT, T] // points to next balancing decision
+		insertPtr *node[PT, T] // points to insertion point for new connections
+		size      int          // amount of connections inside current location
+	}
+
+	// Grid is fixed-level load balancer that is specifically
+	// balances between connections grouped by locations.
+	//
+	Grid[PT connection[T], T any] struct {
+		mx *sync.Mutex
+
+		locDta map[string]locationData[PT, T] // connections per location
+
+		locPrefM map[string]struct{} // locations with configured preference
+		locPref  []string            // ordered preference for locations
+
+		connsPerEndpoint int  // amount of connsPerEndpoint to spawn for each endpoint
+		ignoreLocations  bool // use default locations for all endpoints
+	}
+
+	// Config provides initial params for Grid.
+	Config struct {
+		// LocationPreference defines location processing sequence.
+		// See GetConn().
+		LocationPreference []string
+
+		// ConnsPerEndpoint specifies how many individual connections will be
+		// spawned during Add() call.
+		ConnsPerEndpoint int
+
+		// IgnoreLocations explicitly sets to ignore LocationPreference and
+		// use common default location for all endpoints.
+		// If LocationPreference is empty, default location is used regardless
+		// of this flag's value.
+		IgnoreLocations bool
+	}
+
+	createFunc[PT connection[T], T any] func() (PT, error)
+)
+
+// NewGrid creates new grid load balancer.
+func NewGrid[PT connection[T], T any](cfg Config) *Grid[PT, T] {
+	if len(cfg.LocationPreference) == 0 {
+		cfg.IgnoreLocations = true
+	}
+	if cfg.ConnsPerEndpoint < 1 {
+		cfg.ConnsPerEndpoint = minConnectionsPerEndpoint
+	}
+
+	grid := &Grid[PT, T]{
+		mx: &sync.Mutex{},
+
+		locDta:   make(map[string]locationData[PT, T]),
+		locPrefM: make(map[string]struct{}),
+
+		locPref:          cfg.LocationPreference,
+		connsPerEndpoint: cfg.ConnsPerEndpoint,
+		ignoreLocations:  cfg.IgnoreLocations,
+	}
+
+	for _, location := range cfg.LocationPreference {
+		grid.locPrefM[location] = struct{}{}
+	}
+
+	return grid
+}
+
+// GetConn selects balanced connection based on available
+// locations and alive connections.
+// - It will always return connections from first location
+// in LocationPreference list.
+// - If there's no alive connections in first location,
+// next location from the list is used (and so on).
+// - If there's no alive connections in any of preferred locations,
+// other existing location will be checked in no particular order.
+// - If IgnoreLocations is set, it uses only default location.
+//
+// Within one location connections are selected using round-robin approach.
+func (g *Grid[PT, T]) GetConn() PT {
+	g.mx.Lock()
+	defer g.mx.Unlock()
+
+	if g.ignoreLocations {
+		return g.lookupInLocation(defaultLocation)
+	}
+
+	// lookup in available locations according to preference
+	for _, loc := range g.locPref {
+		if _, ok := g.locDta[loc]; ok {
+			conn := g.lookupInLocation(loc)
+			if conn != nil {
+				return conn
+			}
+		}
+	}
+
+	// If some locations are not in preference,
+	// lookup inside them as well.
+	for loc := range g.locDta {
+		if _, ok := g.locPrefM[loc]; !ok {
+			conn := g.lookupInLocation(loc)
+			if conn != nil {
+				return conn
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *Grid[PT, T]) lookupInLocation(location string) PT {
+	var (
+		loc  = g.locDta[location]
+		ptr  = loc.lookupPtr
+		size = loc.size
+	)
+
+	// Get next alive conn,
+	// making full circle in worst case.
+	for ; size > 0; size-- {
+		if ptr.conn.Alive() {
+			loc.lookupPtr = ptr.next
+			g.locDta[location] = loc
+
+			return ptr.conn
+		}
+		ptr = ptr.next
+	}
+
+	return nil
+}
+
+// Add creates connections in specified location.
+func (g *Grid[PT, T]) Add(location string, creatF createFunc[PT, T]) error {
+	// Spawn connections
+	var (
+		head, prev *node[PT, T]
+	)
+	for range g.connsPerEndpoint {
+		conn, err := creatF()
+		if err != nil {
+			for ; head != nil; head = head.next {
+				_ = head.conn.Close()
+			}
+			return errors.Join(ErrConnCreate, err)
+		}
+
+		if prev == nil {
+			prev = &node[PT, T]{conn: conn}
+			head = prev
+		} else {
+			prev.next = &node[PT, T]{conn: conn}
+			prev = prev.next
+		}
+	}
+
+	// Attach connections to location
+	g.mx.Lock()
+	defer g.mx.Unlock()
+
+	if g.ignoreLocations {
+		location = defaultLocation
+	}
+	locDta, ok := g.locDta[location]
+	if ok && locDta.size != 0 {
+		// insert conn list into location list
+		locDta.insertPtr.next, prev.next = head, locDta.insertPtr.next
+		locDta.size += g.connsPerEndpoint
+		g.locDta[location] = locDta
+
+		return nil
+	}
+
+	// First time seeing this location
+	prev.next = head // cycle nodes
+	g.locDta[location] = locationData[PT, T]{
+		lookupPtr: head,
+		insertPtr: prev,
+		size:      g.connsPerEndpoint,
+	}
+
+	return nil
+}
+
+// Delete deletes connections from location.
+// It uses linear search within location to find all matching connections.
+func (g *Grid[PT, T]) Delete(location string, id uint64) error {
+	g.mx.Lock()
+	defer g.mx.Unlock()
+
+	if g.ignoreLocations {
+		location = defaultLocation
+	}
+	locDta, ok := g.locDta[location]
+	switch {
+	case !ok:
+		return ErrUnknownLocation
+	case locDta.size == 0:
+		return ErrEmptyLocation
+	case locDta.size == g.connsPerEndpoint:
+		// We have connsPerEndpoint of only one endpoint.
+		if locDta.insertPtr.conn.ID() == id {
+			// delete last remaining endpoint
+			delete(g.locDta, location)
+
+			return nil
+		}
+
+		return ErrNoSuchID
+	}
+
+	var (
+		start *node[PT, T]
+
+		// prev and ptr are starting at border between some endpoints
+		ptr  = locDta.insertPtr.next
+		prev = locDta.insertPtr
+	)
+
+	// New conns for the same endpoint are always added
+	// as continuous range. To delete conns by endpoint id
+	// we need to find conn (start) preceding first conn of this endpoint
+	// then find first conn of next endpoint.
+	// And finally point start.next to conn of next endpoint.
+	for size := locDta.size; size >= 0; size-- {
+		if ptr.conn.ID() == id {
+			// found first conn in deletion range
+			start = prev
+
+			// scroll to conn of next endpoint
+			for ctr := 0; ctr < g.connsPerEndpoint; ctr++ {
+				ptr = ptr.next
+			}
+			// found last conn
+			start.next = ptr
+
+			// Scroll lookup and insert pointers
+			// if they are inside deleted range.
+			for locDta.insertPtr.conn.ID() == id {
+				locDta.insertPtr = locDta.insertPtr.next
+			}
+			for locDta.lookupPtr.conn.ID() == id {
+				locDta.lookupPtr = locDta.lookupPtr.next
+			}
+
+			g.locDta[location] = locDta
+
+			return nil
+		}
+
+		prev, ptr = ptr, ptr.next
+	}
+
+	return ErrNoSuchID
+}

--- a/internal/transport/balancing/v4/grid.go
+++ b/internal/transport/balancing/v4/grid.go
@@ -270,13 +270,13 @@ func (g *Grid[PT, T]) Delete(location string, id uint64) error {
 			// found last conn
 			start.next = ptr
 
-			// Scroll lookup and insert pointers
-			// if they are inside deleted range.
-			for locDta.insertPtr.conn.ID() == id {
-				locDta.insertPtr = locDta.insertPtr.next
+			// Warp lookup and insert pointers
+			// if they are in deleted range.
+			if locDta.insertPtr.conn.ID() == id {
+				locDta.insertPtr = ptr
 			}
-			for locDta.lookupPtr.conn.ID() == id {
-				locDta.lookupPtr = locDta.lookupPtr.next
+			if locDta.lookupPtr.conn.ID() == id {
+				locDta.lookupPtr = ptr
 			}
 
 			g.locDta[location] = locDta

--- a/internal/transport/balancing/v4/grid_benchmark_test.go
+++ b/internal/transport/balancing/v4/grid_benchmark_test.go
@@ -1,0 +1,27 @@
+package v3
+
+import "testing"
+
+func BenchmarkGetConn(b *testing.B) {
+	const (
+		children = 3
+	)
+	balancer := NewGrid[*conn, conn](Config{
+		ConnsPerEndpoint: children,
+		IgnoreLocations:  true, // all connections will be in default location
+	})
+
+	fillTree(b, balancer, func(pID uint64) *conn {
+		c := &conn{
+			alive: true,
+			id:    pID,
+		}
+
+		return c
+	}, children)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = balancer.GetConn()
+	}
+}

--- a/internal/transport/balancing/v4/grid_test.go
+++ b/internal/transport/balancing/v4/grid_test.go
@@ -1,0 +1,484 @@
+package v3
+
+import (
+	"context"
+	"hash/maphash"
+	"math"
+	"math/rand"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type conn struct {
+	loc   string
+	uid   uint64
+	id    uint64
+	alive bool
+}
+
+func (c *conn) Alive() bool {
+	return c.alive
+}
+
+func (c *conn) Close() error {
+	return nil
+}
+
+func (c *conn) ID() uint64 {
+	return c.id
+}
+
+func TestAddDel(t *testing.T) {
+	type args struct {
+		lvl          int
+		addEndpoint  [2]string
+		delEndpoint  [2]string
+		locationPref []string
+		connNum      int
+		alive        bool
+	}
+	tests := []struct {
+		name        string
+		args        args
+		addErr      error
+		delErr      error
+		nilAfterAdd bool
+		nilAfterDel bool
+	}{
+		{
+			name: "alive",
+			args: args{
+				lvl:         3,
+				addEndpoint: [2]string{"1", "2"},
+				delEndpoint: [2]string{"1", "2"},
+				connNum:     1,
+				alive:       true,
+			},
+			nilAfterAdd: false,
+			nilAfterDel: true,
+		},
+		{
+			name: "not alive",
+			args: args{
+				lvl:         3,
+				addEndpoint: [2]string{"1", "2"},
+				delEndpoint: [2]string{"1", "2"},
+				connNum:     10,
+				alive:       false,
+			},
+			nilAfterAdd: true,
+			nilAfterDel: true,
+		},
+		{
+			name: "del wrong loc",
+			args: args{
+				lvl:          3,
+				addEndpoint:  [2]string{"1", "2"},
+				delEndpoint:  [2]string{"3", "4"},
+				locationPref: []string{"1"},
+				connNum:      10,
+				alive:        true,
+			},
+			nilAfterAdd: false,
+			nilAfterDel: false,
+			delErr:      ErrUnknownLocation,
+		},
+		{
+			name: "del wrong id default loc",
+			args: args{
+				lvl:         3,
+				addEndpoint: [2]string{"1", "2"},
+				delEndpoint: [2]string{"3", "4"},
+				connNum:     10,
+				alive:       true,
+			},
+			nilAfterAdd: false,
+			nilAfterDel: false,
+			delErr:      ErrNoSuchID,
+		},
+		{
+			name: "del wrong id",
+			args: args{
+				lvl:         3,
+				addEndpoint: [2]string{"1", "2"},
+				delEndpoint: [2]string{"1", "3"},
+				connNum:     10,
+				alive:       true,
+			},
+			nilAfterAdd: false,
+			nilAfterDel: false,
+			delErr:      ErrNoSuchID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seed := maphash.MakeSeed()
+
+			balancer := NewGrid[*conn, conn](Config{
+				LocationPreference: tt.args.locationPref,
+				ConnsPerEndpoint:   2,
+			})
+
+			err := balancer.Add(tt.args.addEndpoint[0], func() (*conn, error) {
+				return &conn{
+					alive: tt.args.alive,
+					id:    maphash.String(seed, tt.args.addEndpoint[1]),
+				}, nil
+			})
+			require.NoError(t, err)
+
+			got := balancer.GetConn()
+			require.Equal(t, tt.nilAfterAdd, got == nil)
+
+			err = balancer.Delete(tt.args.delEndpoint[0], maphash.String(seed, tt.args.delEndpoint[1]))
+			require.ErrorIs(t, err, tt.delErr)
+
+			got = balancer.GetConn()
+			require.Equal(t, tt.nilAfterDel, got == nil)
+		})
+	}
+}
+
+func TestLocationFallback(t *testing.T) {
+	balancer := NewGrid[*conn, conn](Config{
+		ConnsPerEndpoint:   4,
+		LocationPreference: []string{"aaa", "bbb", "ccc"},
+	})
+
+	locMp := make(map[string][]*conn, 20)
+
+	require.NoError(t, balancer.Add("aaa", func() (*conn, error) {
+		conn_ := &conn{alive: true, loc: "aaa"}
+		locMp["aaa"] = append(locMp["aaa"], conn_)
+		return conn_, nil
+	}))
+	require.NoError(t, balancer.Add("bbb", func() (*conn, error) {
+		conn_ := &conn{alive: true, loc: "bbb"}
+		locMp["bbb"] = append(locMp["bbb"], conn_)
+		return conn_, nil
+	}))
+	require.NoError(t, balancer.Add("ccc", func() (*conn, error) {
+		conn_ := &conn{alive: true, loc: "ccc"}
+		locMp["ccc"] = append(locMp["ccc"], conn_)
+		return conn_, nil
+	}))
+	require.NoError(t, balancer.Add("ddd", func() (*conn, error) {
+		conn_ := &conn{alive: true, loc: "ddd"}
+		locMp["ddd"] = append(locMp["ddd"], conn_)
+		return conn_, nil
+	}))
+
+	getConns := func(t *testing.T, loc string) {
+		t.Helper()
+
+		for range len(locMp) {
+			conn_ := balancer.GetConn()
+			require.NotNil(t, conn_)
+			require.Equal(t, loc, conn_.loc)
+		}
+	}
+
+	setAlive := func(t *testing.T, loc string, alive bool) {
+		t.Helper()
+
+		for _, conn_ := range locMp[loc] {
+			conn_.alive = alive
+		}
+	}
+
+	// first location should be used
+	getConns(t, "aaa")
+	// set aaa to be not alive
+	setAlive(t, "aaa", false)
+	// second location should be used
+	getConns(t, "bbb")
+	// set aaa to be not alive
+	setAlive(t, "bbb", false)
+	// third location should be used
+	getConns(t, "ccc")
+	// set ccc to be not alive
+	setAlive(t, "ccc", false)
+	// forth location should be used
+	getConns(t, "ddd")
+	// set ddd to be not alive
+	setAlive(t, "ddd", false)
+	// no connections should be available
+	for range len(locMp) {
+		require.Nil(t, balancer.GetConn())
+	}
+	// set ddd to be not alive
+	setAlive(t, "ddd", true)
+	// forth location should be used
+	getConns(t, "ddd")
+	// set ccc to alive
+	setAlive(t, "ccc", true)
+	// third location should be used
+	getConns(t, "ccc")
+	// set bbb to be not alive
+	setAlive(t, "bbb", true)
+	// second location should be used
+	getConns(t, "bbb")
+	// set aaa to be not alive
+	setAlive(t, "aaa", true)
+	// first location should be used
+	getConns(t, "aaa")
+}
+
+func TestTreeFillAndGet(t *testing.T) {
+	type args struct {
+		children   int
+		numGetConn int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "9endpoints_9conns_30000getConns",
+			args: args{
+				children:   9,
+				numGetConn: 30000,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			balancer := NewGrid[*conn, conn](Config{
+				ConnsPerEndpoint: tt.args.children,
+				IgnoreLocations:  true, // all connections will be in default location
+			})
+
+			stats := make(map[uint64]int)
+
+			fillTree(t, balancer, func(pID uint64) *conn {
+				c := &conn{
+					alive: true,
+					id:    pID,
+				}
+				for {
+					uid := pID*1000 + uint64(rand.Intn(1000))
+					if _, ok := stats[uid]; !ok {
+						c.uid = uid
+						break
+					}
+				}
+				stats[c.uid] = 0
+
+				return c
+			}, tt.args.children)
+
+			t.Log("tree is filled")
+
+			// get connsPerEndpoint from the tree
+			mux := sync.Mutex{}
+			wg := sync.WaitGroup{}
+			wg.Add(tt.args.numGetConn)
+			for i := 0; i < tt.args.numGetConn; i++ {
+				go func() {
+					got := balancer.GetConn()
+					require.NotNil(t, got)
+
+					mux.Lock()
+					stats[got.uid]++
+					mux.Unlock()
+					wg.Done()
+				}()
+			}
+
+			wg.Wait()
+
+			mx, mn := 0, tt.args.numGetConn
+			for _, count := range stats {
+				if count > mx {
+					mx = count
+				}
+				if count < mn {
+					mn = count
+				}
+			}
+
+			assert.Equal(t, int(math.Pow(float64(tt.args.children), float64(3))), len(stats),
+				"connections amount should be equal to number of children at bottom level")
+			assert.Greater(t, mn, 0, "all connections must've been used")
+			assert.True(t, mx-1 == mn || mx == mn, "connection usage should be monotonous")
+
+			t.Log("min hit:", mn, "max hit:", mx, "unique:", len(stats))
+		})
+	}
+}
+
+func TestTreeGetAddDelConcurrent(t *testing.T) {
+	const (
+		delAfter    = 2000 * time.Millisecond
+		delInterval = 500 // msecs
+		addInterval = 100 * time.Millisecond
+
+		testDuration = 10 * time.Second
+
+		workerCount = 100
+	)
+
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name: "ignore location",
+			config: Config{
+				ConnsPerEndpoint: 2,
+			},
+		},
+		{
+			name: "do not ignore location",
+			config: Config{
+				ConnsPerEndpoint:   2,
+				LocationPreference: []string{"#placeholder#"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seed := maphash.MakeSeed()
+
+			balancer := NewGrid[*conn, conn](tt.config)
+
+			var (
+				newConns, delConns            atomic.Uint64
+				createFail, delFail, nilConns atomic.Uint64
+			)
+
+			wg := &sync.WaitGroup{}
+
+			addDel := func(IDs ...string) {
+				newConns.Add(1)
+				connID := maphash.String(seed, IDs[0]+IDs[1])
+				errAdd := balancer.Add(IDs[0], func() (*conn, error) {
+					return &conn{
+						alive: true,
+						id:    connID,
+					}, nil
+				})
+				if errAdd != nil {
+					createFail.Add(1)
+
+					return
+				}
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					deletingAfter := delAfter - delInterval + time.Duration(rand.Intn(2*delInterval))*time.Millisecond
+					time.Sleep(deletingAfter)
+					errDel := balancer.Delete(IDs[0], connID)
+					if errDel != nil {
+						delFail.Add(1)
+					} else {
+						delConns.Add(1)
+					}
+				}()
+			}
+
+			addDel("a", "b")
+
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(testDuration))
+			defer cancel()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				uniq := make(map[string]struct{})
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(addInterval):
+						for {
+							loc, endp := strconv.Itoa(rand.Int()), strconv.Itoa(rand.Int())
+							if _, ok := uniq[loc+endp]; !ok {
+								uniq[loc+endp] = struct{}{}
+								addDel(loc, endp)
+								break
+							}
+						}
+					}
+				}
+			}()
+
+			gotConns := &atomic.Uint64{}
+			for wkr := 0; wkr < workerCount; wkr++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+							conn_ := balancer.GetConn()
+							if conn_ == nil {
+								nilConns.Add(1)
+							} else {
+								gotConns.Add(1)
+							}
+						}
+					}
+				}()
+			}
+
+			wg.Wait()
+			t.Log("added new: ", newConns.Load())
+			t.Log("deleted: ", delConns.Load())
+			t.Log("got connections: ", gotConns.Load())
+			t.Log("create fail: ", createFail.Load())
+			t.Log("delete fail: ", delFail.Load())
+			t.Log("get fail: ", nilConns.Load())
+			if createFail.Load() > 0 || delFail.Load() > 0 || nilConns.Load() > 0 {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func fillTree(tb testing.TB, balancer *Grid[*conn, conn], connFunc func(uint64) *conn, numCh int) {
+	tb.Helper()
+
+	var (
+		genLvl func(lvl int, seq []int)
+	)
+	genLvl = func(lvl int, seq []int) {
+		if lvl == 1 {
+			pID := pathID(seq...)
+			err := balancer.Add(strconv.Itoa(seq[0]), func() (*conn, error) {
+				return connFunc(pID), nil
+			})
+			require.NoError(tb, err)
+
+			return
+		}
+
+		for i := 1; i <= numCh; i++ {
+			genLvl(lvl-1, append(seq, i))
+		}
+	}
+
+	genLvl(3, make([]int, 0, 3))
+}
+
+func pathID(vals ...int) uint64 {
+	mul := 1
+	id := uint64(0)
+	for i := len(vals) - 1; i >= 0; i-- {
+		id += uint64(vals[i] * mul)
+		mul *= 10
+	}
+	return id
+}

--- a/internal/transport/dispatcher/dynamic.go
+++ b/internal/transport/dispatcher/dynamic.go
@@ -8,7 +8,7 @@ import (
 	"github.com/adwski/ydb-go-query/internal/endpoints"
 	"github.com/adwski/ydb-go-query/internal/logger"
 	"github.com/adwski/ydb-go-query/internal/transport"
-	balancer "github.com/adwski/ydb-go-query/internal/transport/balancing/v3"
+	balancing "github.com/adwski/ydb-go-query/internal/transport/balancing/v4"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -26,7 +26,7 @@ type (
 	// and acts as grpc transport.
 	Dynamic struct {
 		logger   logger.Logger
-		balancer *balancer.Grid[*transport.Connection, transport.Connection]
+		balancer *balancing.Grid[*transport.Connection, transport.Connection]
 		invoker  *invoker
 
 		discovery EndpointsProvider
@@ -44,12 +44,12 @@ type (
 		TransportCredentials credentials.TransportCredentials
 		DB                   string
 		InitNodes            []string
-		Balancer             balancer.Config
+		Balancing            balancing.Config
 	}
 )
 
 func NewDynamic(cfg Config) *Dynamic {
-	grid := balancer.NewGrid[*transport.Connection, transport.Connection](cfg.Balancer)
+	grid := balancing.NewGrid[*transport.Connection, transport.Connection](cfg.Balancing)
 	return &Dynamic{
 		logger:               cfg.Logger,
 		discovery:            cfg.EndpointsProvider,

--- a/internal/transport/dispatcher/invoker.go
+++ b/internal/transport/dispatcher/invoker.go
@@ -6,7 +6,7 @@ import (
 
 	localErrs "github.com/adwski/ydb-go-query/internal/errors"
 	"github.com/adwski/ydb-go-query/internal/transport"
-	balancing "github.com/adwski/ydb-go-query/internal/transport/balancing/v3"
+	balancing "github.com/adwski/ydb-go-query/internal/transport/balancing/v4"
 	"github.com/adwski/ydb-go-query/internal/xcontext"
 
 	"google.golang.org/grpc"

--- a/internal/transport/dispatcher/static.go
+++ b/internal/transport/dispatcher/static.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/adwski/ydb-go-query/internal/transport"
-	balancing "github.com/adwski/ydb-go-query/internal/transport/balancing/v3"
+	balancing "github.com/adwski/ydb-go-query/internal/transport/balancing/v4"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"


### PR DESCRIPTION
V4 balancer has the same approach as v3, but uses linked lists to keep connections within location.

Benchmarks show perf improvement

```
❯ go test -v  -benchmem -bench=. -run=^$ ./internal/transport/balancing/v4/*.go
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkGetConn
BenchmarkGetConn-12    	41495619	        26.67 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	1.463s
❯ go test -v  -benchmem -bench=. -run=^$ ./internal/transport/balancing/v3/*.go
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkGetConn
BenchmarkGetConn-12    	26376150	        39.25 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	1.437s
```